### PR TITLE
get rid of empty PhantomJS console on Windows

### DIFF
--- a/lib/LongRunningChildProcess.coffee
+++ b/lib/LongRunningChildProcess.coffee
@@ -155,9 +155,11 @@ class sanjo.LongRunningChildProcess
     spawnOptions = {
       cwd: options.options.cwd or @_getMeteorAppPath(),
       env: env,
-      detached: true,
       stdio: stdio
     }
+    if process.platform != 'win32'
+      spawnOptions.detached = true
+
     command = path.basename options.command
     spawnScript = @_getSpawnScriptPath()
     commandArgs = [spawnScript, @_getMeteorPid(), @taskName, options.command].concat(options.args)


### PR DESCRIPTION
On Windows systems `detach` option doesn't seem to do anything. Except for one small thing - it causes the child process ("spawnscript" that spawns PhantomJS) to create and display an empty console window. This window stays empty because all stdio is redirected to a log file. Removing the detach:true option has prevented that window from popping out and didn't seem to change anything else in test runner's behavior (PhantomJS ran the tests properly and had the same problems with hot-reloading app code)