### PR TITLE
add METEOR_PARENT_PID override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Spawn child processes that survive restarts and exit when the app exits.
 var childProcess = new sanjo.LongRunningChildProcess('myChild');
 var spawnOptions = {
   command: <COMMAND>,
-  args: []
+  args: [],
+  pid: <PARENT_PID> //optional
 };
 childProcess.spawn(spawnOptions);
 ```

--- a/lib/LongRunningChildProcess.coffee
+++ b/lib/LongRunningChildProcess.coffee
@@ -160,7 +160,8 @@ class sanjo.LongRunningChildProcess
     }
     command = path.basename options.command
     spawnScript = @_getSpawnScriptPath()
-    commandArgs = [spawnScript, @_getMeteorPid(), @_getPidFilePath(), @taskName, options.command].concat(options.args)
+    parentPid = options.pid or @_getMeteorPid()
+    commandArgs = [spawnScript, parentPid, @_getPidFilePath(), @taskName, options.command].concat(options.args)
     fs.chmodSync(spawnScript, 0o544)
 
     log.debug("LongRunningChildProcess.spawn is spawning '#{command}'")


### PR DESCRIPTION
I've issue with gagarin testing library. It does not has METEOR_PARENT_PID so child process is never killed. It would be also helpful during development that background process is restarted every time meteor restarts server and this is also available using this options. Only thing you have to do is pass `process.pid` as an spawnOption. 

This is not heavily tested as I cannot build this package but it seems to be only place where Meteor PID is read. 
